### PR TITLE
Handle multiple migraiton versions of index-pattern indices

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/jmoiron/sqlx v1.3.5
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/oauth2 v0.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=

--- a/internal/opensearch/indexpatterns_test.go
+++ b/internal/opensearch/indexpatterns_test.go
@@ -283,8 +283,11 @@ func TestParseIndexPatterns(t *testing.T) {
 						"lagoon-logs-*":      []string{"lagoon-logs-*"},
 						"application-logs-*": []string{"9b7da830-d427-11ed-b326-3348256dd0e8"},
 					},
+					"-152937574_admintenant": {
+						"lagoon-logs-*": []string{"lagoon-logs-*"},
+					},
 				},
-				length:        5,
+				length:        9,
 				lastUpdatedAt: "2023-05-02T07:54:24.736Z",
 			},
 		},

--- a/internal/opensearch/indexpatterns_test.go
+++ b/internal/opensearch/indexpatterns_test.go
@@ -71,8 +71,7 @@ func TestSearchBodyMarshal(t *testing.T) {
 	}
 }
 
-func TestIndexPatternsUnmarshal(t *testing.T) {
-
+func TestParseIndexPatterns(t *testing.T) {
 	type parseIndexPatternsResponse struct {
 		indexPatterns map[string]map[string][]string
 		length        int
@@ -273,6 +272,20 @@ func TestIndexPatternsUnmarshal(t *testing.T) {
 				},
 				length:        152,
 				lastUpdatedAt: "2022-12-02T17:18:31.585Z",
+			},
+		},
+		"handle multiple kibana indices": {
+			input: "testdata/indexpatterns3.json",
+			expect: parseIndexPatternsResponse{
+				indexPatterns: map[string]map[string][]string{
+					"global_tenant": {
+						"router-logs-*":      []string{"router-logs-*"},
+						"lagoon-logs-*":      []string{"lagoon-logs-*"},
+						"application-logs-*": []string{"9b7da830-d427-11ed-b326-3348256dd0e8"},
+					},
+				},
+				length:        5,
+				lastUpdatedAt: "2023-05-02T07:54:24.736Z",
 			},
 		},
 	}

--- a/internal/opensearch/testdata/indexpatterns3.json
+++ b/internal/opensearch/testdata/indexpatterns3.json
@@ -1,0 +1,119 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 13,
+    "total": 13
+  },
+  "hits": {
+    "hits": [
+      {
+        "_id": "index-pattern:9b7da830-d427-11ed-b326-3348256dd0e8",
+        "_index": ".kibana_1",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "application-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-06T03:03:38.452Z"
+        },
+        "sort": [
+          1680750218452
+        ]
+      },
+      {
+        "_id": "index-pattern:9b7da830-d427-11ed-b326-3348256dd0e8",
+        "_index": ".kibana_2",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "application-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-06T03:03:38.452Z"
+        },
+        "sort": [
+          1680750218452
+        ]
+      },
+      {
+        "_id": "index-pattern:d872ab00-d427-11ed-b326-3348256dd0e8",
+        "_index": ".kibana_1",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "container-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-06T03:05:11.854Z"
+        },
+        "sort": [
+          1680750311854
+        ]
+      },
+      {
+        "_id": "index-pattern:lagoon-logs-*",
+        "_index": ".kibana_2",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "lagoon-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-05-02T07:48:39.336Z"
+        },
+        "sort": [
+          1683013719336
+        ]
+      },
+      {
+        "_id": "index-pattern:router-logs-*",
+        "_index": ".kibana_2",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "router-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-05-02T07:54:24.736Z"
+        },
+        "sort": [
+          1683014064736
+        ]
+      }
+    ],
+    "max_score": null,
+    "total": {
+      "relation": "eq",
+      "value": 174
+    }
+  },
+  "timed_out": false,
+  "took": 13
+}

--- a/internal/opensearch/testdata/indexpatterns3.json
+++ b/internal/opensearch/testdata/indexpatterns3.json
@@ -69,6 +69,86 @@
       },
       {
         "_id": "index-pattern:lagoon-logs-*",
+        "_index": ".kibana_-152937574_admintenant_1",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "lagoon-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-24T05:22:06.165Z"
+        },
+        "sort": [
+          1682313726165
+        ]
+      },
+      {
+        "_id": "index-pattern:lagoon-logs-*",
+        "_index": ".kibana_-152937574_admintenant_2",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "lagoon-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-24T05:22:06.165Z"
+        },
+        "sort": [
+          1682313726165
+        ]
+      },
+      {
+        "_id": "index-pattern:router-logs-*",
+        "_index": ".kibana_-152937574_admintenant_1",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "router-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-24T05:22:06.165Z"
+        },
+        "sort": [
+          1682313726165
+        ]
+      },
+      {
+        "_id": "index-pattern:container-logs-*",
+        "_index": ".kibana_-152937574_admintenant_1",
+        "_score": null,
+        "_source": {
+          "index-pattern": {
+            "timeFieldName": "@timestamp",
+            "title": "container-logs-*"
+          },
+          "migrationVersion": {
+            "index-pattern": "7.6.0"
+          },
+          "references": [],
+          "type": "index-pattern",
+          "updated_at": "2023-04-24T05:22:06.165Z"
+        },
+        "sort": [
+          1682313726165
+        ]
+      },
+      {
+        "_id": "index-pattern:lagoon-logs-*",
         "_index": ".kibana_2",
         "_score": null,
         "_source": {
@@ -111,7 +191,7 @@
     "max_score": null,
     "total": {
       "relation": "eq",
-      "value": 174
+      "value": 9
     }
   },
   "timed_out": false,


### PR DESCRIPTION
Old migrations of .kibana indices containing index patterns should be ignored, as only the latest migration is valid.

In practice, this means only looking at the index with the highest number suffix (indicating migration).