### PR TITLE
feat: allow users with access to Group tenants to view and list reports

### DIFF
--- a/internal/sync/roles.go
+++ b/internal/sync/roles.go
@@ -91,14 +91,9 @@ func generateProjectGroupRole(group keycloak.Group) (
 	}
 	return name, &opensearch.Role{
 		RolePermissions: opensearch.RolePermissions{
-			// Allow users to read and download Reports
-			// https://github.com/opensearch-project/security/blob/2.7.0.0/config/
-			// 	roles.yml#L126-L132
-			ClusterPermissions: []string{
-				"cluster:admin/opendistro/reports/instance/list",
-				"cluster:admin/opendistro/reports/instance/get",
-				"cluster:admin/opendistro/reports/menu/download",
-			},
+			// use an empty slice instead of omitting this entirely because the
+			// Opensearch API errors if this field is omitted.
+			ClusterPermissions: []string{},
 			IndexPermissions: []opensearch.IndexPermission{
 				{
 					AllowedActions: []string{

--- a/internal/sync/roles.go
+++ b/internal/sync/roles.go
@@ -91,7 +91,12 @@ func generateProjectGroupRole(group keycloak.Group) (
 	}
 	return name, &opensearch.Role{
 		RolePermissions: opensearch.RolePermissions{
+			// Allow users to read and download Reports
+			// https://github.com/opensearch-project/security/blob/2.7.0.0/config/
+			// 	roles.yml#L126-L132
 			ClusterPermissions: []string{
+				"cluster:admin/opendistro/reports/instance/list",
+				"cluster:admin/opendistro/reports/instance/get",
 				"cluster:admin/opendistro/reports/menu/download",
 			},
 			IndexPermissions: []opensearch.IndexPermission{
@@ -171,7 +176,12 @@ func generateRegularGroupRole(log *zap.Logger, projectNames map[int]string,
 	}
 	return group.Name, &opensearch.Role{
 		RolePermissions: opensearch.RolePermissions{
+			// Allow users to read and download Reports
+			// https://github.com/opensearch-project/security/blob/2.7.0.0/config/
+			// 		roles.yml#L126-L132
 			ClusterPermissions: []string{
+				"cluster:admin/opendistro/reports/instance/list",
+				"cluster:admin/opendistro/reports/instance/get",
 				"cluster:admin/opendistro/reports/menu/download",
 			},
 			IndexPermissions: indexPermissions,

--- a/internal/sync/roles_test.go
+++ b/internal/sync/roles_test.go
@@ -1,7 +1,6 @@
 package sync_test
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/alecthomas/assert"
@@ -53,9 +52,7 @@ func TestGenerateIndexPermissionPatterns(t *testing.T) {
 		t.Run(name, func(tt *testing.T) {
 			indexPatterns := sync.GenerateIndexPermissionPatterns(log, tc.input.pids,
 				tc.input.projectNames)
-			if !reflect.DeepEqual(indexPatterns, tc.expect) {
-				tt.Fatalf("got %v, expected %v", indexPatterns, tc.expect)
-			}
+			assert.Equal(tt, tc.expect, indexPatterns, "indexPatterns")
 		})
 	}
 }
@@ -72,7 +69,7 @@ func TestGenerateRoles(t *testing.T) {
 		input  generateRolesInput
 		expect generateRolesOutput
 	}{
-		"generate roles for project group": {
+		"generate roles for regular group": {
 			input: generateRolesInput{
 				groups: []keycloak.Group{
 					{
@@ -127,7 +124,7 @@ func TestGenerateRoles(t *testing.T) {
 				},
 			},
 		},
-		"generate roles for regular group": {
+		"generate roles for project group": {
 			input: generateRolesInput{
 				groups: []keycloak.Group{
 					{
@@ -151,11 +148,7 @@ func TestGenerateRoles(t *testing.T) {
 				roles: map[string]opensearch.Role{
 					"p27": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{
-								"cluster:admin/opendistro/reports/instance/list",
-								"cluster:admin/opendistro/reports/instance/get",
-								"cluster:admin/opendistro/reports/menu/download",
-							},
+							ClusterPermissions: []string{},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -183,9 +176,7 @@ func TestGenerateRoles(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(tt *testing.T) {
 			roles := sync.GenerateRoles(log, tc.input.groups, tc.input.projectNames)
-			if !reflect.DeepEqual(roles, tc.expect.roles) {
-				tt.Fatalf("got:\n%v\nexpected:\n%v\n", roles, tc.expect.roles)
-			}
+			assert.Equal(tt, tc.expect.roles, roles, "roles")
 		})
 	}
 }
@@ -702,11 +693,7 @@ func TestCalculateRoleDiff(t *testing.T) {
 					},
 					"p11": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{
-								"cluster:admin/opendistro/reports/instance/list",
-								"cluster:admin/opendistro/reports/instance/get",
-								"cluster:admin/opendistro/reports/menu/download",
-							},
+							ClusterPermissions: []string{},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -761,11 +748,7 @@ func TestCalculateRoleDiff(t *testing.T) {
 					},
 					"p11": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{
-								"cluster:admin/opendistro/reports/instance/list",
-								"cluster:admin/opendistro/reports/instance/get",
-								"cluster:admin/opendistro/reports/menu/download",
-							},
+							ClusterPermissions: []string{},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{

--- a/internal/sync/roles_test.go
+++ b/internal/sync/roles_test.go
@@ -4,19 +4,18 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/alecthomas/assert"
 	"github.com/uselagoon/lagoon-opensearch-sync/internal/keycloak"
 	"github.com/uselagoon/lagoon-opensearch-sync/internal/opensearch"
 	"github.com/uselagoon/lagoon-opensearch-sync/internal/sync"
 	"go.uber.org/zap"
 )
 
-type generateIndexPermissionPatternsInput struct {
-	pids         []int
-	projectNames map[int]string
-}
-
 func TestGenerateIndexPermissionPatterns(t *testing.T) {
+	type generateIndexPermissionPatternsInput struct {
+		pids         []int
+		projectNames map[int]string
+	}
 	var testCases = map[string]struct {
 		input  generateIndexPermissionPatternsInput
 		expect []string
@@ -61,16 +60,14 @@ func TestGenerateIndexPermissionPatterns(t *testing.T) {
 	}
 }
 
-type generateRolesInput struct {
-	groups       []keycloak.Group
-	projectNames map[int]string
-}
-
-type generateRolesOutput struct {
-	roles map[string]opensearch.Role
-}
-
 func TestGenerateRoles(t *testing.T) {
+	type generateRolesInput struct {
+		groups       []keycloak.Group
+		projectNames map[int]string
+	}
+	type generateRolesOutput struct {
+		roles map[string]opensearch.Role
+	}
 	var testCases = map[string]struct {
 		input  generateRolesInput
 		expect generateRolesOutput
@@ -101,6 +98,8 @@ func TestGenerateRoles(t *testing.T) {
 					"drupal-example": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -153,6 +152,8 @@ func TestGenerateRoles(t *testing.T) {
 					"p27": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -189,17 +190,15 @@ func TestGenerateRoles(t *testing.T) {
 	}
 }
 
-type calculateRoleDiffInput struct {
-	existing map[string]opensearch.Role
-	required map[string]opensearch.Role
-}
-
-type calculateRoleDiffOutput struct {
-	toCreate map[string]opensearch.Role
-	toDelete []string
-}
-
 func TestCalculateRoleDiff(t *testing.T) {
+	type calculateRoleDiffInput struct {
+		existing map[string]opensearch.Role
+		required map[string]opensearch.Role
+	}
+	type calculateRoleDiffOutput struct {
+		toCreate map[string]opensearch.Role
+		toDelete []string
+	}
 	var testCases = map[string]struct {
 		input  calculateRoleDiffInput
 		expect calculateRoleDiffOutput
@@ -209,7 +208,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 				existing: map[string]opensearch.Role{
 					"drupal-example": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -233,7 +236,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 					},
 					"drupal-example2": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -258,6 +265,8 @@ func TestCalculateRoleDiff(t *testing.T) {
 					"p11": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -283,7 +292,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 				required: map[string]opensearch.Role{
 					"drupal-example": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -307,7 +320,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 					},
 					"internaltest": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -333,6 +350,8 @@ func TestCalculateRoleDiff(t *testing.T) {
 					"p11": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -357,6 +376,8 @@ func TestCalculateRoleDiff(t *testing.T) {
 					"p23": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -384,7 +405,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 				toCreate: map[string]opensearch.Role{
 					"internaltest": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -410,6 +435,8 @@ func TestCalculateRoleDiff(t *testing.T) {
 					"p23": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -440,7 +467,161 @@ func TestCalculateRoleDiff(t *testing.T) {
 				existing: map[string]opensearch.Role{
 					"internaltest": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal9-solr-_-.+/",
+										"/^(application|container|lagoon|router)-logs-react-example-_-.+/",
+										"/^(application|container|lagoon|router)-logs-drupal10-prerelease-_-.+/",
+										"/^(application|container|lagoon|router)-logs-nolongerexists-_-.+/",
+										"/^(application|container|lagoon|router)-logs-drupal-example-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_write"},
+									TenantPatterns: []string{"internaltest"},
+								},
+							},
+						},
+					},
+					"p11": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal-example-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+				},
+				required: map[string]opensearch.Role{
+					"internaltest": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal9-solr-_-.+/",
+										"/^(application|container|lagoon|router)-logs-react-example-_-.+/",
+										"/^(application|container|lagoon|router)-logs-drupal10-prerelease-_-.+/",
+										"/^(application|container|lagoon|router)-logs-drupal-example-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_write"},
+									TenantPatterns: []string{"internaltest"},
+								},
+							},
+						},
+					},
+					"p11": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal-example-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: calculateRoleDiffOutput{
+				toCreate: map[string]opensearch.Role{
+					"internaltest": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal9-solr-_-.+/",
+										"/^(application|container|lagoon|router)-logs-react-example-_-.+/",
+										"/^(application|container|lagoon|router)-logs-drupal10-prerelease-_-.+/",
+										"/^(application|container|lagoon|router)-logs-drupal-example-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_write"},
+									TenantPatterns: []string{"internaltest"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"update report role": {
+			input: calculateRoleDiffInput{
+				existing: map[string]opensearch.Role{
+					"internaltest": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -492,7 +673,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 				required: map[string]opensearch.Role{
 					"internaltest": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -518,6 +703,8 @@ func TestCalculateRoleDiff(t *testing.T) {
 					"p11": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
 								"cluster:admin/opendistro/reports/menu/download",
 							},
 							IndexPermissions: []opensearch.IndexPermission{
@@ -545,7 +732,11 @@ func TestCalculateRoleDiff(t *testing.T) {
 				toCreate: map[string]opensearch.Role{
 					"internaltest": {
 						RolePermissions: opensearch.RolePermissions{
-							ClusterPermissions: []string{"cluster:admin/opendistro/reports/menu/download"},
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
 							IndexPermissions: []opensearch.IndexPermission{
 								{
 									AllowedActions: []string{
@@ -568,6 +759,32 @@ func TestCalculateRoleDiff(t *testing.T) {
 							},
 						},
 					},
+					"p11": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{
+								"cluster:admin/opendistro/reports/instance/list",
+								"cluster:admin/opendistro/reports/instance/get",
+								"cluster:admin/opendistro/reports/menu/download",
+							},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal-example-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -576,16 +793,8 @@ func TestCalculateRoleDiff(t *testing.T) {
 		t.Run(name, func(tt *testing.T) {
 			toCreate, toDelete :=
 				sync.CalculateRoleDiff(tc.input.existing, tc.input.required)
-			if !((len(toCreate) == 0 && len(tc.expect.toCreate) == 0) ||
-				reflect.DeepEqual(toCreate, tc.expect.toCreate)) {
-				tt.Fatalf("toCreate got:\n%v\nexpected:\n%v\n",
-					spew.Sdump(toCreate), spew.Sdump(tc.expect.toCreate))
-			}
-			if !((len(toDelete) == 0 && len(tc.expect.toDelete) == 0) ||
-				reflect.DeepEqual(toDelete, tc.expect.toDelete)) {
-				tt.Fatalf("toDelete got:\n%v\nexpected:\n%v\n",
-					toDelete, tc.expect.toDelete)
-			}
+			assert.Equal(tt, tc.expect.toCreate, toCreate, "toCreate")
+			assert.Equal(tt, tc.expect.toDelete, toDelete, "toDelete")
 		})
 	}
 }


### PR DESCRIPTION
This fixes the errors that are otherwise seen in the Reporting tab of Opensearch Dashboards UI.

This removes the reporting permissions for project-only users because these users cannot generate reports anyway due to lack of project-specific index patterns in the global tenant.