### PR TITLE
fix: ensure the admin_tenant has global index patterns

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,9 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         args: --timeout=180s
+        # temporarily pin the linter version until
+        # https://github.com/golangci/golangci-lint/issues/3862 is fixed
+        version: v1.52.2
   commitlint:
     runs-on: ubuntu-latest
     steps:

--- a/internal/sync/indexpatterns.go
+++ b/internal/sync/indexpatterns.go
@@ -35,7 +35,7 @@ var (
 	indexNameInvalid = regexp.MustCompile(`[^a-z0-9]+`)
 	// specialTenants are not associated with a Lagoon group and receive just the
 	// globalIndexPatterns
-	specialTenants = []string{"global_tenant"}
+	specialTenants = []string{"global_tenant", "admin_tenant"}
 )
 
 // hashPrefix returns an Opensearch-index-name-sanitized copy of given a string
@@ -87,7 +87,9 @@ func calculateIndexPatternDiff(log *zap.Logger,
 	// calculate index patterns to delete
 	toDelete := map[string]map[string][]string{}
 	for index, patterns := range existing {
-		// ignore any custom index patterns created in the admin_tenant
+		// do not delete any custom index patterns created in the admin_tenant
+		// these are sometimes useful for administrators, and aren't visible to
+		// customers (they don't have access to the admin_tenant)
 		if index == hashPrefix("admin_tenant") {
 			continue
 		}

--- a/internal/sync/indexpatterns_test.go
+++ b/internal/sync/indexpatterns_test.go
@@ -431,6 +431,12 @@ func TestGenerateIndexPatterns(t *testing.T) {
 					`lagoon-logs-*`:      true,
 					`router-logs-*`:      true,
 				},
+				"admin_tenant": {
+					`application-logs-*`: true,
+					`container-logs-*`:   true,
+					`lagoon-logs-*`:      true,
+					`router-logs-*`:      true,
+				},
 			},
 		},
 		"high-level test legacy group index patterns": {
@@ -475,6 +481,12 @@ func TestGenerateIndexPatterns(t *testing.T) {
 					`router-logs-*`:                    true,
 				},
 				"global_tenant": {
+					`application-logs-*`: true,
+					`container-logs-*`:   true,
+					`lagoon-logs-*`:      true,
+					`router-logs-*`:      true,
+				},
+				"admin_tenant": {
 					`application-logs-*`: true,
 					`container-logs-*`:   true,
 					`lagoon-logs-*`:      true,


### PR DESCRIPTION
This change ensures that the `admin_tenant` gets the global index patterns (i.e. the non-project-specific ones).