### PR TITLE
chore: enforce scope in dependabot commit messages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,8 @@
 version: 2
 updates:
 - package-ecosystem: github-actions
+  commit-message:
+    include: scope
   directory: /
   schedule:
     interval: monthly
@@ -12,6 +14,8 @@ updates:
       - "minor"
       - "patch"
 - package-ecosystem: docker
+  commit-message:
+    include: scope
   directory: /
   schedule:
     interval: monthly
@@ -23,6 +27,8 @@ updates:
       - "minor"
       - "patch"
 - package-ecosystem: gomod
+  commit-message:
+    include: scope
   directory: /
   schedule:
     interval: monthly


### PR DESCRIPTION
Otherwise dependabot tries to auto-sense commit conventions and
sometimes fails. We need the scope for the commit linter.
