### PR TITLE
chore: fix error message from Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,7 @@ version: 2
 updates:
 - package-ecosystem: github-actions
   commit-message:
+    prefix: chore
     include: scope
   directory: /
   schedule:
@@ -15,6 +16,7 @@ updates:
       - "patch"
 - package-ecosystem: docker
   commit-message:
+    prefix: chore
     include: scope
   directory: /
   schedule:
@@ -28,6 +30,7 @@ updates:
       - "patch"
 - package-ecosystem: gomod
   commit-message:
+    prefix: chore
     include: scope
   directory: /
   schedule:


### PR DESCRIPTION
Apparently there is an undocumented dependency between the include field
and the prefix field.
