### PR TITLE
chore: support read-only api-db connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ The deployment requires:
 | `KEYCLOAK_CLIENT_SECRET`         | Client secret of `lagoon-opensearch-sync` Keycloak client. |                                                                             |
 | `OPENSEARCH_ADMIN_PASSWORD`      | Password for the Opensearch `admin` user.                  |                                                                             |
 
-3. Command `/lagoon-opensearch-sync`.
+3. If you are utilising a read-only connection to the api-db, either via a read-replica, or dedicated account:
+
+| Name                             | Description                                                | Example                                                                     |
+| ---                              | ---                                                        | ---                                                                         |
+| `API_DB_RO_ADDRESS`                 | Internal service name of an API DB read-only replica.                       | `lagoon-core-api-db`                                                        |
+| `API_DB_RO_USERNAME`                | Read-only user for the API DB.                                    |  |
+| `API_DB_RO_PASSWORD`                | Password for the read-only user for the API DB.                                    |    |
+
+4. Command `/lagoon-opensearch-sync`.
 
 ## Advanced usage
 

--- a/cmd/lagoon-opensearch-sync/dump-projects.go
+++ b/cmd/lagoon-opensearch-sync/dump-projects.go
@@ -13,10 +13,10 @@ import (
 
 // DumpProjectsCmd represents the `dump-projects` command.
 type DumpProjectsCmd struct {
-	APIDBAddress  string `kong:"required,env='API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
+	APIDBAddress  string `kong:"required,env='API_DB_RO_ADDRESS,API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
 	APIDBDatabase string `kong:"default='infrastructure',env='API_DB_DATABASE',help='Lagoon API DB Database Name'"`
-	APIDBPassword string `kong:"required,env='API_DB_PASSWORD',help='Lagoon API DB Password'"`
-	APIDBUsername string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
+	APIDBPassword string `kong:"required,env='API_DB_RO_PASSWORD,API_DB_PASSWORD',help='Lagoon API DB Password'"`
+	APIDBUsername string `kong:"default='api',env='API_DB_RO_USERNAME,API_DB_USERNAME',help='Lagoon API DB Username'"`
 }
 
 // Run the dump-projects command.

--- a/cmd/lagoon-opensearch-sync/sync.go
+++ b/cmd/lagoon-opensearch-sync/sync.go
@@ -24,10 +24,10 @@ type SyncCmd struct {
 	Objects                     []string      `kong:"enum='tenants,roles,rolesmapping,indexpatterns,indextemplates',default='tenants,roles,rolesmapping,indexpatterns,indextemplates',help='Opensearch objects which will be synchronized'"`
 	LegacyIndexPatternDelimiter bool          `kong:"default='false',help='Use the legacy -* index pattern delimiter instead of -_-*'"`
 	// lagoon DB client fields
-	APIDBAddress  string `kong:"required,env='API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
+	APIDBAddress  string `kong:"required,env='API_DB_RO_ADDRESS,API_DB_ADDRESS',help='Lagoon API DB Address (host[:port])'"`
 	APIDBDatabase string `kong:"default='infrastructure',env='API_DB_DATABASE',help='Lagoon API DB Database Name'"`
-	APIDBPassword string `kong:"required,env='API_DB_PASSWORD',help='Lagoon API DB Password'"`
-	APIDBUsername string `kong:"default='api',env='API_DB_USERNAME',help='Lagoon API DB Username'"`
+	APIDBPassword string `kong:"required,env='API_DB_RO_PASSWORD,API_DB_PASSWORD',help='Lagoon API DB Password'"`
+	APIDBUsername string `kong:"default='api',env='API_DB_RO_USERNAME,API_DB_USERNAME',help='Lagoon API DB Username'"`
 	// keycloak client fields
 	KeycloakClientID     string `kong:"default='lagoon-opensearch-sync',env='KEYCLOAK_CLIENT_ID',help='Keycloak OAuth2 Client ID'"`
 	KeycloakClientSecret string `kong:"required,env='KEYCLOAK_CLIENT_SECRET',help='Keycloak OAuth2 Client Secret'"`


### PR DESCRIPTION
It would be preferable to support read-only access to the api-db.

This can occur two ways (in the future anyway):
* via a manually created read-only user - adding the `API_DB_RO_USERNAME` and `API_DB_RO_PASSWORD` variables to the deployment as additionalEnvs
* via a read-replica (more common in cloud installs) - by adding the `API_DB_RO_ADDRESS` variable to the deployment as additionalEnvs

Kong will resolve the vars in the declared order, so if there is no `_RO_` it will use the version in the chart

For clarity, I created an additional variable(s) to avoid reusing the `API_DB_PASSWORD` variable - as it is a write password in other services that need write access.

```
MariaDB [infrastructure]> CREATE USER 'readonly'@'%' IDENTIFIED BY 'password';
Query OK, 0 rows affected (0.003 sec)

MariaDB [infrastructure]> GRANT SELECT, SHOW VIEW ON infrastructure.* TO 'readonly'@'%';
Query OK, 0 rows affected (0.003 sec)
```