### PR TITLE
Update roles and rolesmapping handling to match Lagoon permission logic

### DIFF
--- a/internal/sync/roles_test.go
+++ b/internal/sync/roles_test.go
@@ -70,7 +70,7 @@ func TestGenerateRoles(t *testing.T) {
 		input  generateRolesInput
 		expect generateRolesOutput
 	}{
-		"generate roles for regular group": {
+		"generate roles for regular group and projects": {
 			input: generateRolesInput{
 				groups: []keycloak.Group{
 					{
@@ -121,10 +121,98 @@ func TestGenerateRoles(t *testing.T) {
 							},
 						},
 					},
+					"p31": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal9-base-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+					"p34": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-somelongerprojectname-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+					"p35": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-drupal10-prerelease-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+					"p36": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-delta-backend-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
-		"generate roles for project group": {
+		"generate roles for projects ignoring project group": {
 			input: generateRolesInput{
 				groups: []keycloak.Group{
 					{
@@ -148,6 +236,28 @@ func TestGenerateRoles(t *testing.T) {
 			},
 			expect: generateRolesOutput{
 				roles: map[string]opensearch.Role{
+					"p26": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-abc-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
 					"p27": {
 						RolePermissions: opensearch.RolePermissions{
 							ClusterPermissions: []string{},
@@ -159,6 +269,121 @@ func TestGenerateRoles(t *testing.T) {
 									},
 									IndexPatterns: []string{
 										"/^(application|container|lagoon|router)-logs-beta-ui-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+					"p48": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-somelongprojectname-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"generate roles for multi-project project group": {
+			input: generateRolesInput{
+				groups: []keycloak.Group{
+					{
+						ID: "3fc60c90-b72d-4704-8a57-80438adac98d",
+						GroupUpdateRepresentation: keycloak.GroupUpdateRepresentation{
+							Name: "project-beta-ui",
+							Attributes: map[string][]string{
+								"type": {`project-default-group`},
+							},
+						},
+					},
+				},
+				projectNames: map[int]string{
+					26: "abc",
+					27: "beta-ui",
+					48: "somelongprojectname",
+				},
+				groupProjectsMap: map[string][]int{
+					"3fc60c90-b72d-4704-8a57-80438adac98d": {48, 27, 26},
+				},
+			},
+			expect: generateRolesOutput{
+				roles: map[string]opensearch.Role{
+					"p26": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-abc-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+					"p27": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-beta-ui-_-.+/",
+									},
+								},
+							},
+							TenantPermissions: []opensearch.TenantPermission{
+								{
+									AllowedActions: []string{"kibana_all_read"},
+									TenantPatterns: []string{"global_tenant"},
+								},
+							},
+						},
+					},
+					"p48": {
+						RolePermissions: opensearch.RolePermissions{
+							ClusterPermissions: []string{},
+							IndexPermissions: []opensearch.IndexPermission{
+								{
+									AllowedActions: []string{
+										"read",
+										"indices:monitor/settings/get",
+									},
+									IndexPatterns: []string{
+										"/^(application|container|lagoon|router)-logs-somelongprojectname-_-.+/",
 									},
 								},
 							},

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -112,7 +112,7 @@ func Sync(ctx context.Context, log *zap.Logger, l LagoonDBService,
 		case "roles":
 			syncRoles(ctx, log, groups, projectNames, roles, groupProjectsMap, o, dryRun)
 		case "rolesmapping":
-			syncRolesMapping(ctx, log, groups, roles, groupProjectsMap, o, dryRun)
+			syncRolesMapping(ctx, log, groups, projectNames, roles, groupProjectsMap, o, dryRun)
 		case "indexpatterns":
 			syncIndexPatterns(ctx, log, groupsSansGlobal, projectNames, groupProjectsMap,
 				o, d, dryRun, legacyIndexPatternDelimiter)


### PR DESCRIPTION
Previously lagoon-opensearch-sync was creating project roles and rolesmapping by iterating over groups, including for project groups. This logic was based on the incorrect assumption that projects and project groups (AKA project default groups) are a 1:1 mapping.

In reality, project groups can have multiple project "members". So the new logic ignores the project groups and just uses project IDs and names for roles and rolesmapping. This matches the logic used in the custom Keycloak mapper Lagoon uses to grant roles to Opensearch users.

Closes: #151