### PR TITLE
feat: ignore index templates starting with custom-

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The deployment requires:
 
 3. Command `/lagoon-opensearch-sync`.
 
+## Index templates
+
+To manually create index templates, they can be prefixed with `custom-` so that they will be ignored during the index template sync and not deleted.
+
 ## Advanced usage
 
 This tool can be used to debug Opensearch/Lagoon integration.

--- a/internal/sync/indextemplates.go
+++ b/internal/sync/indextemplates.go
@@ -2,10 +2,13 @@ package sync
 
 import (
 	"context"
+	"strings"
 
 	"github.com/uselagoon/lagoon-opensearch-sync/internal/opensearch"
 	"go.uber.org/zap"
 )
+
+const INDEX_TEMPLATE_IGNORE_PREFIX = "custom-"
 
 // calculateIndexTemplateDiff returns a map of opensearch index templates which
 // should be created, and a slice of index template names which should be
@@ -24,6 +27,9 @@ func calculateIndexTemplateDiff(existing,
 	// calculate index templates to delete
 	var toDelete []string
 	for name, eIndexTemplate := range existing {
+		if strings.HasPrefix(name, INDEX_TEMPLATE_IGNORE_PREFIX) {
+			continue
+		}
 		rIndexTemplate, ok := required[name]
 		if !ok || !indexTemplatesEqual(rIndexTemplate, eIndexTemplate) {
 			toDelete = append(toDelete, name)

--- a/internal/sync/indextemplates_test.go
+++ b/internal/sync/indextemplates_test.go
@@ -1,0 +1,97 @@
+package sync
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/uselagoon/lagoon-opensearch-sync/internal/opensearch"
+)
+
+func TestCalculateIndexTemplateDiff(t *testing.T) {
+	type input struct {
+		existing map[string]opensearch.IndexTemplate
+		required map[string]opensearch.IndexTemplate
+	}
+	type output struct {
+		toCreate map[string]opensearch.IndexTemplate
+		toDelete []string
+	}
+	var testCases = map[string]struct {
+		input  input
+		expect output
+	}{
+		"no diff": {
+			input: input{
+				existing: map[string]opensearch.IndexTemplate{
+					"routerlogs": {Name: "routerlogs"},
+				},
+				required: map[string]opensearch.IndexTemplate{
+					"routerlogs": {Name: "routerlogs"},
+				},
+			},
+			expect: output{
+				toCreate: map[string]opensearch.IndexTemplate{},
+				toDelete: nil,
+			},
+		},
+		"create index template": {
+			input: input{
+				existing: map[string]opensearch.IndexTemplate{},
+				required: map[string]opensearch.IndexTemplate{
+					"routerlogs": {Name: "routerlogs"},
+				},
+			},
+			expect: output{
+				toCreate: map[string]opensearch.IndexTemplate{
+					"routerlogs": {Name: "routerlogs"},
+				},
+				toDelete: nil,
+			},
+		},
+		"delete index template": {
+			input: input{
+				existing: map[string]opensearch.IndexTemplate{
+					"routerlogs":       {Name: "routerlogs"},
+					"manually-created": {Name: "manually-created"},
+				},
+				required: map[string]opensearch.IndexTemplate{
+					"routerlogs": {Name: "routerlogs"},
+				},
+			},
+			expect: output{
+				toCreate: map[string]opensearch.IndexTemplate{},
+				toDelete: []string{
+					"manually-created",
+				},
+			},
+		},
+		"keep custom index template": {
+			input: input{
+				existing: map[string]opensearch.IndexTemplate{
+					"routerlogs":  {Name: "routerlogs"},
+					"custom-logs": {Name: "custom-logs"},
+				}, required: map[string]opensearch.IndexTemplate{
+					"routerlogs": {Name: "routerlogs"},
+				},
+			},
+			expect: output{
+				toCreate: map[string]opensearch.IndexTemplate{},
+				toDelete: nil,
+			},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(tt *testing.T) {
+			toCreate, toDelete := calculateIndexTemplateDiff(tc.input.existing, tc.input.required)
+			if !reflect.DeepEqual(toCreate, tc.expect.toCreate) {
+				tt.Fatalf("got:\n%v\nexpected:\n%v\n", toCreate,
+					tc.expect.toCreate)
+			}
+
+			if !reflect.DeepEqual(toDelete, tc.expect.toDelete) {
+				tt.Fatalf("got:\n%v\nexpected:\n%v\n", toDelete,
+					tc.expect.toDelete)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows automatically managed and manually created custom index
patterns to coexist.
